### PR TITLE
require networking before jail autostart

### DIFF
--- a/rc.d/ioc
+++ b/rc.d/ioc
@@ -4,7 +4,7 @@
 #
 
 # PROVIDE: ioc
-# REQUIRE: LOGIN cleanvar sshd ZFS
+# REQUIRE: LOGIN cleanvar sshd ZFS NETWORKING
 # BEFORE:  securelevel
 # KEYWORD: shutdown
 


### PR DESCRIPTION
Adds NETWORKING to REQUIRE list of the rc.d script.